### PR TITLE
OS-8115 Add support for zfs.sync.change-key channel program

### DIFF
--- a/kbmadm/kbmadm.c
+++ b/kbmadm/kbmadm.c
@@ -629,7 +629,7 @@ do_add_recovery(int argc, char **argv)
 	int c;
 	boolean_t activate_now = B_FALSE;
 
-	while ((c = getopt(argc, argv, "ft:r:")) != -1) {
+	while ((c = getopt(argc, argv, "aft:r:")) != -1) {
 		switch (c) {
 		case 'a':
 			activate_now = B_TRUE;

--- a/lua/activate_prog.lua
+++ b/lua/activate_prog.lua
@@ -16,18 +16,11 @@
 --  dataset     (string)    The dataset to act on
 --  ebox        (string)    The zfs property of the current ebox
 --  stagedebox  (string)    The zfs property of the staged ebox
---  keyhex      (string)    The staged ebox key (as a hex encoded string).
+--  hidden_args.keyhex
+--              (string)    The staged ebox key (as a hex encoded string).
 
 args = ...
-
--- Due to limitations to the current zcp API, we cannot pass a raw binary
--- value as an argument. Instead, we pass the key as a hex string and
--- so we can convert it within the channel program
-key = args.keyhex:gsub('..',
-    function (ch)
-        return string.char(tonumber(ch, 16))
-    end
-)
+key = args.hidden_args.keyhex
 
 hasold = false
 hasnew = false
@@ -51,7 +44,7 @@ if (not hasnew) then
     return "No ebox has been staged"
 end
 
-err = zfs.check.change_key(args.dataset, key)
+err = zfs.check.change_key(args.dataset, key, 'hex')
 if err ~= 0 then
     return err
 end
@@ -71,7 +64,7 @@ if err ~= 0 then
     return err
 end
 
-err = zfs.sync.change_key(args.dataset, key)
+err = zfs.sync.change_key(args.dataset, key, 'hex')
 if err ~= 0 and hasold then
     zfs.sync.set_prop(args.dataset, args.ebox, oldebox)
     return err


### PR DESCRIPTION
With the corresponding illumos-joyent ticket, the LUA interface was changed slightly in anticipation of upstreaming -- specifically a third argument was added to support either 'raw' or 'hex' keys. While you cannot pass a raw binary string to a LUA channel program, the 'raw' support is preserved in case the channel program itself wishes to generate a binary key through some means.

Since kbmd passes key values as hex, we can simplify things a bit and just pass the hex value directly to `zfs.sync.change_key`.